### PR TITLE
Support configuration from environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "envy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +277,7 @@ name = "movine"
 version = "0.4.3"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -701,6 +707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
+"checksum dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 "checksum envy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f938a4abd5b75fe3737902dbc2e79ca142cc1526827a9e40b829a086758531a9"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "envy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +272,7 @@ name = "movine"
 version = "0.4.3"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "envy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -692,6 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
+"checksum envy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f938a4abd5b75fe3737902dbc2e79ca142cc1526827a9e40b829a086758531a9"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
 "checksum fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["command-line-utilities", "database"]
 [dependencies]
 postgres = "0.15.2"
 chrono = "0.4.6"
+envy = "0.4"
 fern = "0.5.7"
 structopt = "0.2.14"
 toml = "0.4.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["command-line-utilities", "database"]
 [dependencies]
 postgres = "0.15.2"
 chrono = "0.4.6"
+dotenv = "0.15"
 envy = "0.4"
 fern = "0.5.7"
 structopt = "0.2.14"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The first step to get started with Movine is to set the configuration. Configura
 
   You can configure the SQLite adaptor using an `SQLITE_FILE` environment variable.
 
+  Movine supports [`.env`](https://github.com/dotenv-rs/dotenv#usage) files as a source of configuration.
+
 Next, you can run the `init` command to set everything up, the `generate` command to create your first migration, and once those are written you can run `up` to apply them.
 ```
 $ movine init

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Movine is a simple database migration manager that aims to be compatible with real-world migration work. Many migration managers get confused with complicated development strategies for the migrations. Movine attempts to solve this issue by keeping track of the unique hashes for the `up.sql` and `down.sql` for each migration. This allows users to easily keep track of whether their local migration history matches the one on the database.
 
-This project is currently in *very* early stages, and should be considered a proof-of-concept. The base functionality is implemented, but things should be expected to change. 
+This project is currently in *very* early stages, and should be considered a proof-of-concept. The base functionality is implemented, but things should be expected to change.
 
 Movine does *not* aim to be an ORM. Consider [diesel](http://diesel.rs/) instead if you want an ORM.
 
@@ -20,22 +20,32 @@ Then there are the more complicated ones, which Movine was specifically designed
 - Variant: Found locally but a different version is applied to the database
 - Divergent: Not found locally but applied to the database
 
-## Getting Started 
-The first step to get started with Movine is to set up the `movine.toml`. This file stores the connection parameters that Movine needs in order to connect to the database. In the future this file will also hold various parameters to customize the way Movine operates.
+## Getting Started
 
-```
-# movine.toml
-[postgres]
-host = {host} 
-database = {db} 
-user = {username}
-password = {pass}
-port = {port}
+The first step to get started with Movine is to set the configuration. Configuration can be supplied either through a `movile.toml` file or environment variables:
 
-## Or use the Sqlite adaptor
-[sqlite]
-file={file}
-```
+- **`movine.toml`**
+
+  This file stores the connection parameters that Movine needs in order to connect to the database. In the future this file will also hold   various parameters to customize the way Movine operates.
+
+  ```toml
+  [postgres]
+  host = {host}
+  database = {db}
+  user = {username}
+  password = {pass}
+  port = {port}
+
+  ## Or use the Sqlite adaptor
+  [sqlite]
+  file={file}
+  ```
+
+- **Environment variables**
+
+  You can configure the PostgreSQL adaptor using the environment variables described in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-envars.html); namely `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD`. All are currently required.
+
+  You can configure the SQLite adaptor using an `SQLITE_FILE` environment variable.
 
 Next, you can run the `init` command to set everything up, the `generate` command to create your first migration, and once those are written you can run `up` to apply them.
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,16 @@ impl Config {
         Ok(config)
     }
 
+    pub fn from_env() -> Option<Self> {
+        let postgres = envy::prefixed("PG").from_env().ok();
+        let sqlite = envy::prefixed("SQLITE_").from_env().ok();
+        if postgres.is_none() && sqlite.is_none() {
+            None
+        } else {
+            Some(Config { postgres, sqlite })
+        }
+    }
+
     pub fn into_adaptor(self) -> Result<Adaptor> {
         match self {
             Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod logger;
 
 fn main() {
     logger::init().expect("Could not initialize the logger.");
+    dotenv::dotenv().ok();
     match run() {
         Ok(()) => {}
         Err(e) => println!("Error: {}", e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,10 @@ fn main() {
 }
 
 fn run() -> Result<()> {
-    let config = Config::from_file(&"movine.toml")?;
+    let config = Config::from_file(&"movine.toml").or_else(|error| match Config::from_env() {
+        Some(config) => Ok(config),
+        None => Err(error),
+    })?;
     let adaptor = config.into_adaptor()?;
     match adaptor {
         Adaptor::Postgres(adaptor) => {


### PR DESCRIPTION
I've taken a quick stab at adding environment variable support in the least intrusive way I could think of using [`envy`](https://crates.io/crates/envy) and only attempting to load when loading the configuration file fails. I updated the [`README.md`](https://github.com/byronwasti/movine/blob/6b920f51a73f335d8e2485ac7842a3a0dc636a25/README.md#getting-started) with instructions for using file or environment configuration.

I've also added [`dotenv`](https://crates.io/crates/dotenv) since this seems like quite a common tool for CLI configuration. It's a shame it's included even when installed as a library, it seems there's an [RFC to support per-target dependencies](https://github.com/rust-lang/rfcs/pull/2887) but no conclusion yet.

Any errors encountered by `Config::from_env` are ignored, including IO errors when accessing the environment or missing environment variables, which I'm not totally happy with but I'm not sure how best to handle those without ending up with a slightly awkward error message ("missing movine.toml or required environment variables"?).

I see this has come up already in https://github.com/byronwasti/movine/issues/1#issuecomment-615497929, so if you are thinking about another approach I'm happy to close this or take your feedback on how you would like to see it implemented!