### PR TITLE
fix: return non-zero code when error occurs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use cli::Opt;
 fn main() {
     dotenv::dotenv().ok();
     match run() {
-        Ok(()) => {}
+        Ok(_) => {}
         Err(e) => {
             eprintln!("Error: {}", e);
             std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
         Err(e) => {
             eprintln!("Error: {}", e);
             std::process::exit(1);
-        },
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,10 @@ fn main() {
     dotenv::dotenv().ok();
     match run() {
         Ok(()) => {}
-        Err(e) => eprintln!("Error: {}", e),
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        },
     }
 }
 


### PR DESCRIPTION
when i using `movine` in CI pipeline, and i configure the wrong environment variable `DATABASE_URL`,  it printed `Error: Error in Postgres: error connecting to server: Connection refused (os error 111)`, but the pipeline responded that is passed. 
