### PR TITLE
Make Postgres password optional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -149,7 +149,7 @@ impl Config {
                     host = params.host,
                     port = params.port,
                     database = params.database,
-                )
+                ),
             };
             let conn = if let Some(cert) = &params.sslcert {
                 let cert = fs::read(cert)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,14 +134,23 @@ impl Config {
 
     pub fn into_pg_conn_from_config(self) -> Result<postgres::Client> {
         if let Some(ref params) = self.postgres {
-            let url = format!(
-                "postgresql://{user}:{password}@{host}:{port}/{database}",
-                user = params.user,
-                password = params.password,
-                host = params.host,
-                port = params.port,
-                database = params.database,
-            );
+            let url = match params.password {
+                Some(ref password) => format!(
+                    "postgresql://{user}:{password}@{host}:{port}/{database}",
+                    user = params.user,
+                    password = password,
+                    host = params.host,
+                    port = params.port,
+                    database = params.database,
+                ),
+                None => format!(
+                    "postgresql://{user}@{host}:{port}/{database}",
+                    user = params.user,
+                    host = params.host,
+                    port = params.port,
+                    database = params.database,
+                )
+            };
             let conn = if let Some(cert) = &params.sslcert {
                 let cert = fs::read(cert)?;
                 let cert = Certificate::from_pem(&cert)?;

--- a/src/config/postgres_params.rs
+++ b/src/config/postgres_params.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 #[derive(Debug, Clone)]
 pub struct PostgresParams {
     pub user: String,
-    pub password: String,
+    pub password: Option<String>,
     pub host: String,
     pub database: String,
     pub port: i32,
@@ -31,7 +31,7 @@ impl TryFrom<&[&RawPostgresParams]> for PostgresParams {
         match params {
             RawPostgresParams {
                 user: Some(user),
-                password: Some(password),
+                password,
                 database: Some(database),
                 host: Some(host),
                 port: Some(port),


### PR DESCRIPTION
Mainly for local dev environments, but Postgres doesn't _require_ a password and this just allows skipping `password` in the config