### PR TITLE
Postgres option sslcert is really sslrootcert

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ database = {db}
 user = {username}
 password = {pass}
 port = {port}
-sslcert = {cert filename}
+sslrootcert = {cert filename}
 
 ## Or use the Sqlite adaptor
 [sqlite]
@@ -50,18 +50,18 @@ file={file}
 database_url={url_string}
 ```
 
-*Note: SSLCert currently does not work when supplying a database_url.*
+*Note: SSLRootCert currently does not work when supplying a database_url.*
 *Note: You should only specify connection details for one database type, or Movine will implicitly choose one*
 
 ### Environment variables
 
-You can configure the PostgreSQL adaptor using the environment variables described in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-envars.html). Specifically `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD` and `PGSSLCERT` are supported.
+You can configure the PostgreSQL adaptor using the environment variables described in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-envars.html). Specifically `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD` and `PGSSLROOTCERT` are supported.
 
 You can configure the SQLite adaptor using an `SQLITE_FILE` environment variable.
 
 Finally, you can also supply a `DATABASE_URL` environment variable.
 
-*Note: SSLCert does not work when using a database URL.*
+*Note: SSLRootCert does not work when using a database URL.*
 
 Movine supports [`.env`](https://github.com/dotenv-rs/dotenv#usage) files as a source of configuration.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,7 +159,7 @@ impl Config {
                     database = params.database,
                 ),
             };
-            let conn = if let Some(cert) = &params.sslcert {
+            let conn = if let Some(cert) = &params.sslrootcert {
                 build_tls_connection(&url, cert)?
             } else {
                 postgres::Client::connect(&url, postgres::NoTls)?

--- a/src/config/postgres_params.rs
+++ b/src/config/postgres_params.rs
@@ -9,7 +9,7 @@ pub struct PostgresParams {
     pub host: String,
     pub database: String,
     pub port: i32,
-    pub sslcert: Option<String>,
+    pub sslrootcert: Option<String>,
 }
 
 impl TryFrom<&[&RawPostgresParams]> for PostgresParams {
@@ -24,7 +24,7 @@ impl TryFrom<&[&RawPostgresParams]> for PostgresParams {
                 acc.host = x.host.to_owned().or(acc.host);
                 acc.database = x.database.to_owned().or(acc.database);
                 acc.port = x.port.to_owned().or(acc.port);
-                acc.sslcert = x.sslcert.to_owned().or(acc.sslcert);
+                acc.sslrootcert = x.sslrootcert.to_owned().or(acc.sslrootcert);
                 acc
             });
 
@@ -35,14 +35,14 @@ impl TryFrom<&[&RawPostgresParams]> for PostgresParams {
                 database: Some(database),
                 host: Some(host),
                 port: Some(port),
-                sslcert,
+                sslrootcert,
             } => Ok(Self {
                 user,
                 password,
                 host,
                 database,
                 port,
-                sslcert,
+                sslrootcert,
             }),
             p => Err(Error::PgParamError {
                 user: p.user.is_some(),
@@ -62,7 +62,7 @@ pub struct RawPostgresParams {
     pub host: Option<String>,
     pub database: Option<String>,
     pub port: Option<i32>,
-    pub sslcert: Option<String>,
+    pub sslrootcert: Option<String>,
 }
 
 impl RawPostgresParams {
@@ -88,7 +88,7 @@ impl Default for RawPostgresParams {
             host: None,
             database: None,
             port: Some(5432),
-            sslcert: None,
+            sslrootcert: None,
         }
     }
 }


### PR DESCRIPTION
This implements the first of the two suggestions from #23.

The existing certificate option is used to specify a file containing a root CA cert to use when validating the database server's certificate.  The option that libpq uses for this is `sslrootcert`, so this PR changes the name here to be consistent with that usage.

https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT